### PR TITLE
Add docs and docker setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [0.1.0] - 2025-06-07
+### Added
+- Primera versión funcional del sistema RAG.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Guía de Contribución
+
+Gracias por tu interés en colaborar con este proyecto. Para mantener una base de código saludable, sigue los pasos a continuación:
+
+1. **Fork y Clona el repositorio**. Trabaja siempre en ramas independientes.
+2. **Instala las dependencias** usando `requirements.txt` y `requirements-dev.txt`.
+3. **Ejecuta las pruebas** con `pytest` antes de enviar un pull request.
+4. **Sigue la guía de estilo** propuesta por `black` e `isort`.
+5. Abre un *pull request* describiendo los cambios realizados.
+
+¡Toda contribución es bienvenida!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "main.py", "--mode", "ui"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Seguridad
+
+Para proteger el sistema y las llaves de API se recomienda:
+
+- Mantener el archivo `.env` fuera del control de versiones.
+- Usar variables de entorno para credenciales sensibles.
+- Actualizar regularmente las dependencias con `pip`.
+- Revisar y aplicar los parches de seguridad del proyecto.
+
+Si encuentras una vulnerabilidad, por favor repórtala creando un issue privado o contactando a los mantenedores.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "7860:7860"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}


### PR DESCRIPTION
## Summary
- provide MIT license text
- add basic contribution guidelines
- initialize project changelog
- implement Dockerfile to run `main.py`
- configure docker-compose for quick startup
- document security recommendations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684437db9174832b824c20b817839d9d