### PR TITLE
Add reusable project setup utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Un sistema completo de Retrieval-Augmented Generation (RAG) construido con Pytho
 ```bash
 python generate_rag_project.py
 ```
+Las funciones reutilizables para crear directorios y archivos se
+encuentran en `src/utils/project_setup.py` por si deseas utilizarlas
+desde tu propio código.
 
 ### 2. Crear entorno virtual
 ```bash

--- a/generate_rag_project.py
+++ b/generate_rag_project.py
@@ -7,37 +7,18 @@ Ejecutar: python generate_rag_project.py
 import os
 from pathlib import Path
 from typing import Dict
+from src.utils.project_setup import (
+    create_project_structure,
+    write_files,
+    DEFAULT_DIRECTORIES,
+)
 
-def create_directory_structure():
-    """Crea la estructura de directorios del proyecto"""
-    directories = [
-        "config",
-        "src/models",
-        "src/storage", 
-        "src/chains",
-        "src/services",
-        "src/utils",
-        "ui",
-        "data/documents",
-        "data/vector_db",
-        "tests",
-        "logs"
-    ]
-    
+def create_directory_structure() -> None:
+    """Utiliza utilidades compartidas para crear la estructura."""
     print("📁 Creando estructura de directorios...")
-    for directory in directories:
-        Path(directory).mkdir(parents=True, exist_ok=True)
+    create_project_structure()
+    for directory in DEFAULT_DIRECTORIES:
         print(f"  ✅ {directory}")
-    
-    # Crear archivos __init__.py
-    init_directories = [
-        "config", "src", "src/models", "src/storage", 
-        "src/chains", "src/services", "src/utils", "ui", "tests"
-    ]
-    
-    for directory in init_directories:
-        init_file = Path(directory) / "__init__.py"
-        init_file.write_text("# -*- coding: utf-8 -*-\n")
 
 def create_file_content() -> Dict[str, str]:
     """Define el contenido de todos los archivos del proyecto"""
@@ -1204,17 +1185,10 @@ MIT License - ver LICENSE para detalles.
 def create_all_files():
     """Crea todos los archivos del proyecto"""
     files_content = create_file_content()
-    
+
     print("📝 Creando archivos del proyecto...")
-    
-    for file_path, content in files_content.items():
-        # Crear directorio padre si no existe
-        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
-        
-        # Escribir contenido
-        with open(file_path, 'w', encoding='utf-8') as f:
-            f.write(content)
-        
+    write_files(files_content)
+    for file_path in files_content:
         print(f"  ✅ {file_path}")
 
 def main():

--- a/main.py
+++ b/main.py
@@ -1,42 +1,15 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-from pathlib import Path
 import argparse
 from src.utils.logger import setup_logger
+from src.utils.project_setup import create_project_structure
 from ui.gradio_app import GradioRAGApp
 from src.services.rag_service import RAGService
 from config.settings import settings
 
 # Configurar logging
 logger = setup_logger()
-
-def create_project_structure():
-    """Crea la estructura de directorios del proyecto"""
-    directories = [
-        "config",
-        "src/models",
-        "src/storage", 
-        "src/chains",
-        "src/services",
-        "src/utils",
-        "ui",
-        "data/documents",
-        "data/vector_db",
-        "tests",
-        "logs"
-    ]
-    
-    for directory in directories:
-        Path(directory).mkdir(parents=True, exist_ok=True)
-        
-        # Crear archivos __init__.py
-        if not directory.startswith("data") and not directory.startswith("logs"):
-            init_file = Path(directory) / "__init__.py"
-            if not init_file.exists():
-                init_file.touch()
-    
-    logger.info("Project structure created successfully")
 
 def main():
     """Función principal"""

--- a/src/utils/project_setup.py
+++ b/src/utils/project_setup.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""Utilities to programmatically create the project structure and files."""
+from pathlib import Path
+from typing import Dict, Iterable
+from src.utils.logger import setup_logger
+
+logger = setup_logger()
+
+DEFAULT_DIRECTORIES = [
+    "config",
+    "src/models",
+    "src/storage",
+    "src/chains",
+    "src/services",
+    "src/utils",
+    "ui",
+    "data/documents",
+    "data/vector_db",
+    "tests",
+    "logs",
+]
+
+
+def create_project_structure(directories: Iterable[str] = DEFAULT_DIRECTORIES) -> None:
+    """Create base folders and ``__init__.py`` files."""
+    for directory in directories:
+        Path(directory).mkdir(parents=True, exist_ok=True)
+
+        if not directory.startswith("data") and not directory.startswith("logs"):
+            init_file = Path(directory) / "__init__.py"
+            if not init_file.exists():
+                init_file.touch()
+
+    logger.info("Project structure created successfully")
+
+
+def write_files(files: Dict[str, str]) -> None:
+    """Create files from a ``path`` -> ``content`` mapping."""
+    for file_path, content in files.items():
+        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(content)
+        logger.info(f"Created file: {file_path}")


### PR DESCRIPTION
## Summary
- add `project_setup` module with reusable file and folder creators
- use the new helpers in `main.py` and `generate_rag_project.py`
- document these utilities in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443b322f0c832b8936eca682b634f1