### PR TITLE
Add Excel and Postgres data loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Un sistema completo de Retrieval-Augmented Generation (RAG) construido con Pytho
 
 ## 🚀 Características
 
-- **Múltiples formatos de documentos**: PDF, TXT, DOCX
+- **Múltiples formatos de documentos**: PDF, TXT, DOCX, XLS/XLSX
+- **Soporte para datos en PostgreSQL**
 - **Interfaz web intuitiva** con Gradio
 - **Modo CLI** para consultas por línea de comandos
 - **Sistema de logging avanzado**

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,8 @@ isort>=5.13.0
 # Additional utilities
 numpy>=1.24.0
 pandas>=2.0.0
+openpyxl>=3.1.0
+psycopg2-binary>=2.9.0
 
 # OpenAI (backup direct client)
 openai>=1.0.0

--- a/src/storage/vector_store.py
+++ b/src/storage/vector_store.py
@@ -196,6 +196,23 @@ class VectorStoreManager:
         except Exception as e:
             logger.error(f"Error adding documents: {e}")
             raise VectorStoreException(f"Failed to add documents: {e}")
+
+    def index_postgres_query(self, conn_str: str, query: str) -> int:
+        """Carga datos desde PostgreSQL e indexa en la base vectorial"""
+        try:
+            docs = self.document_processor.load_from_postgres(conn_str, query)
+            if not docs:
+                logger.warning("No data retrieved from PostgreSQL")
+                return 0
+            chunks = self.document_processor.split_documents(docs)
+            if not chunks:
+                logger.warning("No chunks created from PostgreSQL data")
+                return 0
+            ids = self.add_documents(chunks)
+            return len(ids)
+        except Exception as e:
+            logger.error(f"Error indexing PostgreSQL data: {e}")
+            raise VectorStoreException(f"Failed to index PostgreSQL data: {e}")
     
     def load_and_index_documents(self, documents_path: Optional[str] = None) -> int:
         """Carga e indexa documentos desde un directorio"""


### PR DESCRIPTION
## Summary
- support Excel files and Postgres sources in `DocumentProcessor`
- expose method in `VectorStoreManager` to index Postgres queries
- mention Excel and Postgres in README
- depend on `openpyxl` and `psycopg2-binary`
- test Excel and Postgres loading in unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68443d5c4b68832baa687a68f070838f