### PR TITLE
Add LLM tracing utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ black src/ ui/ tests/
 isort src/ ui/ tests/
 ```
 
+### Base de datos de trazas
+Cada llamada al LLM se registra en `data/traces.db`. Puedes cambiar la ruta con la variable `TRACE_DB_PATH`.
+
+Para consultar los registros:
+```bash
+sqlite3 data/traces.db "SELECT * FROM llm_traces LIMIT 5;"
+```
+
 ## 🔧 Configuración Avanzada
 
 Personaliza la configuración en `.env`:

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,64 +1,75 @@
 # -*- coding: utf-8 -*-
 import os
 from typing import Optional
+
 from pydantic import Field
+
 try:
     from pydantic_settings import BaseSettings
-except ImportError:  # pragma: no cover - fallback for environments without pydantic_settings
+except (
+    ImportError
+):  # pragma: no cover - fallback for environments without pydantic_settings
     from pydantic import BaseSettings
 try:
     from dotenv import load_dotenv
 except ImportError:  # pragma: no cover - fallback if python-dotenv is missing
+
     def load_dotenv(*args, **kwargs):
         return False
 
+
 load_dotenv()
+
 
 class Settings(BaseSettings):
     """Configuración centralizada con selección inteligente de modelos"""
-    
+
     # OpenAI Configuration
     openai_api_key: str = Field(default="", env="OPENAI_API_KEY")
-    
+
     # Modelos disponibles para selección inteligente
     simple_model: str = Field(default="gpt-4o-mini", env="SIMPLE_MODEL")
     complex_model: str = Field(default="gpt-4o", env="COMPLEX_MODEL")
     default_model: str = Field(default="gpt-4o-mini", env="DEFAULT_MODEL")
-    
+
     # COMPATIBILIDAD: mantener model_name para código legacy
     @property
     def model_name(self) -> str:
         """Compatibilidad con código que usa model_name"""
         return self.default_model
-    
+
     # Embedding
-    embedding_model: str = Field(default="text-embedding-3-large", env="EMBEDDING_MODEL")
-    
+    embedding_model: str = Field(
+        default="text-embedding-3-large", env="EMBEDDING_MODEL"
+    )
+
     # Paths
     vector_db_path: str = Field(default="./data/vector_db", env="VECTOR_DB_PATH")
     documents_path: str = Field(default="./data/documents", env="DOCUMENTS_PATH")
-    
+    trace_db_path: str = Field(default="./data/traces.db", env="TRACE_DB_PATH")
+
     # RAG Configuration
     chunk_size: int = Field(default=2200, env="CHUNK_SIZE")
     chunk_overlap: int = Field(default=440, env="CHUNK_OVERLAP")
     max_documents: int = Field(default=10, env="MAX_DOCUMENTS")
-    
+
     # Model Selection Configuration
     enable_smart_selection: bool = Field(default=True, env="ENABLE_SMART_SELECTION")
     complexity_threshold: float = Field(default=0.6, env="COMPLEXITY_THRESHOLD")
-    
+
     # Logging
     log_level: str = Field(default="INFO", env="LOG_LEVEL")
-    
+
     # UI Configuration
     share_gradio: bool = Field(default=False, env="SHARE_GRADIO")
     server_port: int = Field(default=7860, env="SERVER_PORT")
-    
+
     class Config:
         env_file = ".env"
         case_sensitive = False
         # Permitir campos extra para compatibilidad
         extra = "ignore"
+
 
 # Instancia global de configuración
 settings = Settings()

--- a/src/chains/rag_chain.py
+++ b/src/chains/rag_chain.py
@@ -14,6 +14,7 @@ from config.settings import settings
 from src.storage.vector_store import VectorStoreManager
 from src.utils.logger import setup_logger
 from src.utils.exceptions import ChainException
+from src.utils.tracing import trace_llm
 
 logger = setup_logger()
 
@@ -148,6 +149,7 @@ Responde con rigor académico, precisión científica y enfoque específico en l
             logger.error(f"Error creating RAG chain: {e}")
             raise ChainException(f"Failed to create RAG chain: {e}")
     
+    @trace_llm
     def invoke(self, query: str) -> Dict[str, Any]:
         """Ejecuta la cadena RAG con selección inteligente de modelo"""
         try:

--- a/src/utils/tracing.py
+++ b/src/utils/tracing.py
@@ -1,0 +1,161 @@
+import os
+import sqlite3
+import time
+from datetime import datetime
+from functools import wraps
+from typing import Any, Callable, Dict, Optional
+
+from config.settings import settings
+
+
+class LLMTracer:
+    """Simple tracer that stores LLM calls in a SQLite database."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = db_path or settings.trace_db_path
+        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS llm_traces (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT,
+                    model TEXT,
+                    temperature REAL,
+                    prompt TEXT,
+                    tokens_input INTEGER,
+                    tokens_output INTEGER,
+                    latency_ms REAL,
+                    cost_usd REAL,
+                    status TEXT,
+                    error TEXT
+                )
+                """
+            )
+            conn.commit()
+
+    def log_trace(self, data: Dict[str, Any]) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO llm_traces (
+                    timestamp, model, temperature, prompt,
+                    tokens_input, tokens_output, latency_ms,
+                    cost_usd, status, error
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    data.get("timestamp"),
+                    data.get("model"),
+                    data.get("temperature"),
+                    data.get("prompt"),
+                    data.get("tokens_input"),
+                    data.get("tokens_output"),
+                    data.get("latency_ms"),
+                    data.get("cost_usd"),
+                    data.get("status"),
+                    data.get("error"),
+                ),
+            )
+            conn.commit()
+
+
+def trace_llm(func: Callable) -> Callable:
+    """Decorator to trace LLM calls."""
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        tracer = LLMTracer()
+        start = time.perf_counter()
+        try:
+            result = func(*args, **kwargs)
+            latency_ms = (time.perf_counter() - start) * 1000
+            prompt = kwargs.get("query")
+            if prompt is None:
+                if len(args) == 1:
+                    prompt = args[0]
+                elif len(args) >= 2:
+                    prompt = args[1]
+            temperature = kwargs.get("temperature")
+            self_obj = args[0] if args else None
+            if temperature is None and hasattr(self_obj, "temperature"):
+                temperature = getattr(self_obj, "temperature")
+            model = kwargs.get("model_name") or kwargs.get("model")
+            if isinstance(result, dict):
+                model = model or result.get("model")
+                model = model or result.get("model_info", {}).get("selected_model")
+                usage = (
+                    result.get("usage", {})
+                    if isinstance(result.get("usage"), dict)
+                    else {}
+                )
+                tokens_input = (
+                    result.get("tokens_input")
+                    or usage.get("prompt_tokens")
+                    or usage.get("input_tokens")
+                )
+                tokens_output = (
+                    result.get("tokens_output")
+                    or usage.get("completion_tokens")
+                    or usage.get("output_tokens")
+                )
+            else:
+                tokens_input = kwargs.get("tokens_input")
+                tokens_output = kwargs.get("tokens_output")
+            if tokens_input is None:
+                tokens_input = kwargs.get("tokens_input")
+            if tokens_output is None:
+                tokens_output = kwargs.get("tokens_output")
+            cost_usd = None
+            if tokens_input is not None or tokens_output is not None:
+                ti = tokens_input or 0
+                to = tokens_output or 0
+                cost_usd = (ti + to) / 1000 * 0.002
+            tracer.log_trace(
+                {
+                    "timestamp": datetime.utcnow().isoformat(),
+                    "model": model,
+                    "temperature": temperature,
+                    "prompt": prompt,
+                    "tokens_input": tokens_input,
+                    "tokens_output": tokens_output,
+                    "latency_ms": latency_ms,
+                    "cost_usd": cost_usd,
+                    "status": "success",
+                    "error": None,
+                }
+            )
+            return result
+        except Exception as exc:
+            latency_ms = (time.perf_counter() - start) * 1000
+            prompt = kwargs.get("query")
+            if prompt is None:
+                if len(args) == 1:
+                    prompt = args[0]
+                elif len(args) >= 2:
+                    prompt = args[1]
+            temperature = kwargs.get("temperature")
+            self_obj = args[0] if args else None
+            if temperature is None and hasattr(self_obj, "temperature"):
+                temperature = getattr(self_obj, "temperature")
+            model = kwargs.get("model_name") or kwargs.get("model")
+            tracer.log_trace(
+                {
+                    "timestamp": datetime.utcnow().isoformat(),
+                    "model": model,
+                    "temperature": temperature,
+                    "prompt": prompt,
+                    "tokens_input": kwargs.get("tokens_input"),
+                    "tokens_output": kwargs.get("tokens_output"),
+                    "latency_ms": latency_ms,
+                    "cost_usd": None,
+                    "status": "error",
+                    "error": str(exc),
+                }
+            )
+            raise
+
+    return wrapper

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,38 @@
+import sqlite3
+
+from config.settings import settings
+from src.utils.tracing import LLMTracer, trace_llm
+
+
+def setup_temp_db(tmp_path):
+    settings.trace_db_path = str(tmp_path / "traces.db")
+    return LLMTracer(settings.trace_db_path)
+
+
+def create_dummy():
+    @trace_llm
+    def dummy(query: str, model_name: str = "test-model"):
+        return {"answer": "ok", "model_info": {"selected_model": model_name}}
+
+    return dummy
+
+
+def test_trace_success_status(tmp_path):
+    tracer = setup_temp_db(tmp_path)
+    dummy = create_dummy()
+    dummy("hola")
+    conn = sqlite3.connect(settings.trace_db_path)
+    row = conn.execute("SELECT status FROM llm_traces").fetchone()
+    conn.close()
+    assert row[0] == "success"
+
+
+def test_trace_contains_prompt_and_model(tmp_path):
+    tracer = setup_temp_db(tmp_path)
+    dummy = create_dummy()
+    dummy("mundo")
+    conn = sqlite3.connect(settings.trace_db_path)
+    row = conn.execute("SELECT prompt, model FROM llm_traces").fetchone()
+    conn.close()
+    assert row[0] == "mundo"
+    assert row[1] == "test-model"


### PR DESCRIPTION
## Summary
- add SQLite-based LLMTracer and `trace_llm` decorator
- allow configuration of trace database path
- trace `RAGChain.invoke`
- document how to inspect trace DB
- test tracing decorator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844489f4d24832ba33821bbd540ab84