### PR TITLE
Add cost tracking per model

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ isort src/ ui/ tests/
 ```
 
 ### Base de datos de trazas
-Cada llamada al LLM se registra en `data/traces.db`. Puedes cambiar la ruta con la variable `TRACE_DB_PATH`.
+Cada llamada al LLM se registra en `data/traces.db`. Puedes cambiar la ruta con la variable `TRACE_DB_PATH`. El costo se calcula usando los precios definidos en `model_prices`.
 
 Para consultar los registros:
 ```bash
@@ -110,6 +110,9 @@ SIMPLE_MODEL=gpt-4o-mini
 COMPLEX_MODEL=gpt-4o
 DEFAULT_MODEL=gpt-4o-mini
 EMBEDDING_MODEL=text-embedding-3-large
+
+# Precios por modelo (opcional)
+MODEL_PRICES={"gpt-4o":0.02,"gpt-4o-mini":0.01}
 
 # RAG
 CHUNK_SIZE=1500

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic import Field
 
@@ -32,6 +32,11 @@ class Settings(BaseSettings):
     simple_model: str = Field(default="gpt-4o-mini", env="SIMPLE_MODEL")
     complex_model: str = Field(default="gpt-4o", env="COMPLEX_MODEL")
     default_model: str = Field(default="gpt-4o-mini", env="DEFAULT_MODEL")
+
+    # Precios por cada 1000 tokens de los modelos
+    model_prices: Dict[str, float] = Field(
+        default={"gpt-4o": 0.02, "gpt-4o-mini": 0.01}
+    )
 
     # COMPATIBILIDAD: mantener model_name para código legacy
     @property

--- a/src/utils/tracing.py
+++ b/src/utils/tracing.py
@@ -206,7 +206,9 @@ def trace_llm(func: Callable) -> Callable:
             if tokens_input is not None or tokens_output is not None:
                 ti = tokens_input or 0
                 to = tokens_output or 0
-                cost_usd = (ti + to) / 1000 * 0.002
+                price = settings.model_prices.get(model)
+                if price is not None:
+                    cost_usd = (ti + to) / 1000 * price
             tracer_db.log_trace(
                 {
                     "timestamp": datetime.utcnow().isoformat(),


### PR DESCRIPTION
## Summary
- add `model_prices` configuration with per-model pricing
- compute LLM tracing cost using configured model price
- document price mapping in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68447926ffd8832b8dd5c399a8e90043