### PR TITLE
Add daily cost export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Para consultar los registros:
 sqlite3 data/traces.db "SELECT * FROM llm_traces LIMIT 5;"
 ```
 
+Para exportar el costo diario a CSV:
+```bash
+python scripts/export_daily_cost.py
+```
+
 ## 🔧 Configuración Avanzada
 
 Personaliza la configuración en `.env`:

--- a/scripts/export_daily_cost.py
+++ b/scripts/export_daily_cost.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Exportar costo diario de trazas a archivos CSV."""
+
+from __future__ import annotations
+
+import csv
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path("data/traces.db")
+REPORTS_DIR = Path("data/reports")
+
+
+def export_daily_cost(db_path: Path = DB_PATH, reports_dir: Path = REPORTS_DIR) -> None:
+    """Genera un archivo CSV por cada fecha con la suma del costo."""
+    if not db_path.exists():
+        raise FileNotFoundError(f"Database not found: {db_path}")
+
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT DATE(timestamp) AS day, SUM(COALESCE(cost_usd, 0))
+            FROM llm_traces
+            GROUP BY DATE(timestamp)
+            ORDER BY day
+            """
+        ).fetchall()
+
+    for day, total in rows:
+        out_file = reports_dir / f"{day}.csv"
+        with out_file.open("w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["date", "cost_usd"])
+            writer.writerow([day, f"{float(total):.6f}"])
+
+    print(f"Generated {len(rows)} report files in {reports_dir}")
+
+
+if __name__ == "__main__":
+    export_daily_cost()


### PR DESCRIPTION
## Summary
- add `export_daily_cost.py` to generate CSV reports per date
- document how to export trace costs
- include empty `data/reports` directory

## Testing
- `black scripts/export_daily_cost.py`
- `isort scripts/export_daily_cost.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447da5bd6c832b87d766382ed87853