### PR TITLE
Add tracing for model selection

### DIFF
--- a/src/utils/model_selector.py
+++ b/src/utils/model_selector.py
@@ -1,72 +1,145 @@
 # -*- coding: utf-8 -*-
 from typing import Tuple
+
 from config.settings import settings
 from src.utils.logger import setup_logger
+from src.utils.tracing import trace_model_selection
 
 logger = setup_logger()
 
+
 class ModelSelector:
     """Selector inteligente de modelos optimizado para investigación académica"""
-    
+
     def __init__(self):
         # Palabras clave que indican consultas complejas (académicas)
         self.complex_keywords = [
             # Análisis académico profundo
-            'analiza', 'analyze', 'análisis', 'analysis', 'evaluación', 'evaluation',
-            'compara', 'compare', 'contrasta', 'contrast', 'diferencias', 'similarities',
-            'síntesis', 'synthesis', 'integra', 'integrate', 'combina', 'combine',
-            
+            "analiza",
+            "analyze",
+            "análisis",
+            "analysis",
+            "evaluación",
+            "evaluation",
+            "compara",
+            "compare",
+            "contrasta",
+            "contrast",
+            "diferencias",
+            "similarities",
+            "síntesis",
+            "synthesis",
+            "integra",
+            "integrate",
+            "combina",
+            "combine",
             # Metodología y investigación
-            'metodología', 'methodology', 'framework', 'approach', 'método', 'method',
-            'estado del arte', 'state of art', 'literatura', 'literature', 'revisión', 'review',
-            'gaps', 'brechas', 'limitaciones', 'limitations', 'futuro', 'future work',
-            
+            "metodología",
+            "methodology",
+            "framework",
+            "approach",
+            "método",
+            "method",
+            "estado del arte",
+            "state of art",
+            "literatura",
+            "literature",
+            "revisión",
+            "review",
+            "gaps",
+            "brechas",
+            "limitaciones",
+            "limitations",
+            "futuro",
+            "future work",
             # Análisis crítico
-            'crítico', 'critical', 'evalúa', 'evaluate', 'assessment', 'valoración',
-            'investigación', 'research', 'estudio', 'study', 'findings', 'hallazgos',
-            
+            "crítico",
+            "critical",
+            "evalúa",
+            "evaluate",
+            "assessment",
+            "valoración",
+            "investigación",
+            "research",
+            "estudio",
+            "study",
+            "findings",
+            "hallazgos",
             # Conceptos académicos específicos para tu tesis
-            'paper', 'artículo', 'journal', 'conference', 'proceedings',
-            'algoritmo', 'algorithm', 'modelo', 'model', 'técnica', 'technique',
-            'historias de usuario', 'user stories', 'requirements', 'ágil', 'agile',
-            'nlp', 'machine learning', 'deep learning', 'inteligencia artificial',
-            
+            "paper",
+            "artículo",
+            "journal",
+            "conference",
+            "proceedings",
+            "algoritmo",
+            "algorithm",
+            "modelo",
+            "model",
+            "técnica",
+            "technique",
+            "historias de usuario",
+            "user stories",
+            "requirements",
+            "ágil",
+            "agile",
+            "nlp",
+            "machine learning",
+            "deep learning",
+            "inteligencia artificial",
             # Palabras de comparación y relación
-            'ventajas', 'desventajas', 'pros', 'contras', 'advantages', 'disadvantages',
-            'relación', 'relationship', 'impacto', 'impact', 'influencia', 'influence'
+            "ventajas",
+            "desventajas",
+            "pros",
+            "contras",
+            "advantages",
+            "disadvantages",
+            "relación",
+            "relationship",
+            "impacto",
+            "impact",
+            "influencia",
+            "influence",
         ]
-    
+
+    @trace_model_selection
     def select_model(self, query: str) -> Tuple[str, float, str]:
         """Selecciona el modelo apropiado basado en la complejidad de la consulta"""
         if not settings.enable_smart_selection:
             return settings.default_model, 0.5, "Smart selection disabled"
-        
+
         query_lower = query.lower()
         complexity_score = 0.0
-        
+
         # Calcular score basado en palabras clave académicas
         complex_matches = 0
         for keyword in self.complex_keywords:
             if keyword in query_lower:
                 complex_matches += 1
                 complexity_score += 0.15
-        
+
         # Bonificación por longitud (consultas académicas suelen ser largas)
         word_count = len(query.split())
         if word_count > 15:
             complexity_score += 0.2
         elif word_count > 10:
             complexity_score += 0.1
-        
+
         # Bonificación por patrones académicos específicos
-        academic_patterns = ['compara', 'analiza', 'evalúa', 'sintetiza', 'gaps', 'limitaciones']
+        academic_patterns = [
+            "compara",
+            "analiza",
+            "evalúa",
+            "sintetiza",
+            "gaps",
+            "limitaciones",
+        ]
         for pattern in academic_patterns:
             if pattern in query_lower:
                 complexity_score += 0.1
-        
+
         # Normalizar entre 0 y 1
         complexity_score = min(1.0, complexity_score)
-        
+
         # Seleccionar modelo basado en umbral
         if complexity_score >= settings.complexity_threshold:
             selected_model = settings.complex_model
@@ -74,6 +147,8 @@ class ModelSelector:
         else:
             selected_model = settings.simple_model
             reasoning = f"Low complexity ({complexity_score:.2f}) - Using {settings.simple_model} for simple query"
-        
-        logger.info(f"Model selection: {selected_model} | Score: {complexity_score:.2f} | Matches: {complex_matches}")
+
+        logger.info(
+            f"Model selection: {selected_model} | Score: {complexity_score:.2f} | Matches: {complex_matches}"
+        )
         return selected_model, complexity_score, reasoning


### PR DESCRIPTION
## Summary
- add new `trace_model_selection` decorator for tracing model choices
- record selected model and reason in spans
- integrate decorator into the `ModelSelector`
- log warning if no model is selected in debug mode
- test tracing for model selection

## Testing
- `pytest tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6f984370832bb6efa7141fee6426