### PR TITLE
feat: add OCR parser integration

### DIFF
--- a/src/storage/document_parser.py
+++ b/src/storage/document_parser.py
@@ -78,7 +78,17 @@ def parse_image(path: str, lang: str) -> List[Document]:
 
     text = pytesseract.image_to_string(gray, lang=lang)
 
-    return [Document(page_content=text, metadata={"source": path, "type": "image"})]
+    return [
+        Document(
+            page_content=text,
+            metadata={
+                "source": path,
+                "type": "image",
+                "ocr": True,
+                "ocr_lang": lang,
+            },
+        )
+    ]
 
 
 def parse_pdf(path: str, lang: str) -> List[Document]:
@@ -94,7 +104,12 @@ def parse_pdf(path: str, lang: str) -> List[Document]:
                 documents.append(
                     Document(
                         page_content=text,
-                        metadata={"source": path, "page": idx, "type": "pdf"},
+                        metadata={
+                            "source": path,
+                            "page": idx,
+                            "type": "pdf",
+                            "ocr": False,
+                        },
                     )
                 )
             return documents

--- a/tests/test_document_processor_ocr.py
+++ b/tests/test_document_processor_ocr.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+
+from src.storage.document_processor import DocumentProcessor, Document
+
+
+class FakeParser:
+    """Minimal parser used for testing injection and OCR metadata."""
+
+    def __init__(self, needs_ocr_return=False):
+        self.needs_ocr_return = needs_ocr_return
+        self.parse_calls = []
+
+    def parse(self, path, lang="spa+eng"):
+        self.parse_calls.append((path, lang))
+        return [Document(page_content="content", metadata={"ocr": True, "ocr_lang": lang})]
+
+    def needs_ocr(self, path):
+        return self.needs_ocr_return
+
+
+def test_image_uses_parser(tmp_path):
+    img = tmp_path / "test.jpg"
+    img.write_bytes(b"fake")
+
+    parser = FakeParser()
+    processor = DocumentProcessor(parser=parser)
+    docs = processor.load_documents(str(tmp_path))
+
+    assert parser.parse_calls[0][0] == str(img)
+    assert docs[0].metadata["ocr"] is True
+    assert docs[0].metadata["ocr_lang"] == "spa+eng"
+
+
+def test_pdf_with_ocr(tmp_path):
+    pdf = tmp_path / "test.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+
+    parser = FakeParser(needs_ocr_return=True)
+    processor = DocumentProcessor(parser=parser)
+    docs = processor.load_documents(str(tmp_path))
+
+    assert parser.parse_calls[0][0] == str(pdf)
+    assert docs[0].metadata["ocr"] is True
+    assert docs[0].metadata["ocr_lang"] == "spa+eng"


### PR DESCRIPTION
## Summary
- inject configurable document parser into `DocumentProcessor`
- route image files and OCR-ready PDFs through parser
- annotate documents with OCR metadata and language
- add tests for OCR processing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_6897697221c0832b90e01a989e9dd223