### PR TITLE
Add metadata propagation for documents and retrieval

### DIFF
--- a/src/agents/specialized/document_search.py
+++ b/src/agents/specialized/document_search.py
@@ -520,9 +520,12 @@ class DocumentSearchAgent(BaseAgent):
         for i, doc in enumerate(context_docs):
             # Calcular relevancia basada en múltiples factores
             relevance_score = self._calculate_relevance_score(doc, query, position=i)
-            
+
             source_info = {
                 "content": doc.page_content[:200] + "..." if len(doc.page_content) > 200 else doc.page_content,
+                "page_number": doc.metadata.get("page_number"),
+                "section_title": doc.metadata.get("section_title"),
+                "doc_type": doc.metadata.get("doc_type"),
                 "metadata": doc.metadata,
                 "relevance": self._score_to_category(relevance_score),
                 "relevance_score": round(relevance_score, 3)

--- a/src/chains/rag_chain.py
+++ b/src/chains/rag_chain.py
@@ -431,6 +431,9 @@ Responde con rigor académico, precisión científica y enfoque específico en i
                     if len(doc.page_content) > 200
                     else doc.page_content
                 ),
+                "page_number": doc.metadata.get("page_number"),
+                "section_title": doc.metadata.get("section_title"),
+                "doc_type": doc.metadata.get("doc_type"),
                 "metadata": doc.metadata,
             }
             analysis["context_documents"].append(doc_info)

--- a/src/services/rag_service.py
+++ b/src/services/rag_service.py
@@ -337,6 +337,9 @@ class RAGService:
                             if len(doc.page_content) > 200
                             else doc.page_content
                         ),
+                        "page_number": doc.metadata.get("page_number"),
+                        "section_title": doc.metadata.get("section_title"),
+                        "doc_type": doc.metadata.get("doc_type"),
                         "metadata": doc.metadata,
                     }
                     sources.append(source_info)

--- a/src/storage/document_parser.py
+++ b/src/storage/document_parser.py
@@ -83,7 +83,9 @@ def parse_image(path: str, lang: str) -> List[Document]:
             page_content=text,
             metadata={
                 "source": path,
-                "type": "image",
+                "doc_type": "image",
+                "page_number": 1,
+                "section_title": None,
                 "ocr": True,
                 "ocr_lang": lang,
             },
@@ -106,8 +108,9 @@ def parse_pdf(path: str, lang: str) -> List[Document]:
                         page_content=text,
                         metadata={
                             "source": path,
-                            "page": idx,
-                            "type": "pdf",
+                            "page_number": idx,
+                            "section_title": None,
+                            "doc_type": "pdf",
                             "ocr": False,
                         },
                     )
@@ -130,8 +133,9 @@ def parse_pdf(path: str, lang: str) -> List[Document]:
             image.save(img_path, "PNG")
             doc = parse_image(img_path, lang)[0]
             doc.metadata["source"] = path
-            doc.metadata["page"] = idx
-            doc.metadata["type"] = "pdf"
+            doc.metadata["page_number"] = idx
+            doc.metadata["section_title"] = None
+            doc.metadata["doc_type"] = "pdf"
             documents.append(doc)
 
     return documents

--- a/tests/test_document_processor_ocr.py
+++ b/tests/test_document_processor_ocr.py
@@ -30,6 +30,9 @@ def test_image_uses_parser(tmp_path):
     assert parser.parse_calls[0][0] == str(img)
     assert docs[0].metadata["ocr"] is True
     assert docs[0].metadata["ocr_lang"] == "spa+eng"
+    assert docs[0].metadata["doc_type"] == "image"
+    assert docs[0].metadata["page_number"] == 1
+    assert "section_title" in docs[0].metadata
 
 
 def test_pdf_with_ocr(tmp_path):
@@ -43,3 +46,6 @@ def test_pdf_with_ocr(tmp_path):
     assert parser.parse_calls[0][0] == str(pdf)
     assert docs[0].metadata["ocr"] is True
     assert docs[0].metadata["ocr_lang"] == "spa+eng"
+    assert docs[0].metadata["doc_type"] == "pdf"
+    assert docs[0].metadata["page_number"] == 1
+    assert "section_title" in docs[0].metadata

--- a/tests/test_rag_service.py
+++ b/tests/test_rag_service.py
@@ -82,7 +82,17 @@ class TestRAGService:
 
         from src.storage.document_processor import Document
 
-        sample_docs = [Document(page_content="Contenido de ejemplo", metadata={"source_file": "doc1.txt"})]
+        sample_docs = [
+            Document(
+                page_content="Contenido de ejemplo",
+                metadata={
+                    "source_file": "doc1.txt",
+                    "doc_type": "text",
+                    "page_number": 1,
+                    "section_title": "Intro",
+                },
+            )
+        ]
 
         def fake_invoke(question):
             return {
@@ -103,3 +113,6 @@ class TestRAGService:
         assert response["question"] == "Pregunta de prueba"
         assert response["model_info"]["selected_model"] == "fake-model"
         assert response["sources"][0]["metadata"]["source_file"] == "doc1.txt"
+        assert response["sources"][0]["doc_type"] == "text"
+        assert response["sources"][0]["page_number"] == 1
+        assert response["sources"][0]["section_title"] == "Intro"

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -35,6 +35,8 @@ class TestVectorStore:
         assert len(documents) == 1
         assert "prueba" in documents[0].page_content
         assert documents[0].metadata["source_file"] == str(test_file)
+        assert documents[0].metadata["doc_type"] == "text"
+        assert documents[0].metadata["page_number"] == 1
 
     def test_document_processor_with_excel_file(self, temp_dir):
         """Test procesamiento de archivo Excel"""


### PR DESCRIPTION
## Summary
- enrich parsed documents with page number, section title, and doc type
- preserve and propagate metadata through chunking and vector store
- surface metadata fields in retrieval responses

## Testing
- `pytest tests/test_document_processor_ocr.py tests/test_vector_store.py tests/test_rag_service.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic==2.8.0` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68976b9f9c20832bae32601d9d316bed