### PR TITLE
Add OCR dependencies and document Tesseract requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ source venv/bin/activate  # Linux/Mac
 pip install -r requirements.txt
 ```
 
+> **Nota:** Para el procesamiento OCR se requiere tener instalado **Tesseract OCR** en el sistema (`sudo apt install tesseract-ocr` en Debian/Ubuntu, `brew install tesseract` en macOS).
+
 ### 4. Configurar variables de entorno
 ```bash
 # Copia el template de configuración

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,11 @@ loguru>=0.7.2
 pypdf>=4.0.0
 python-docx>=1.1.0
 docx2txt>=0.8
+pytesseract>=0.3.10
+pdf2image>=1.16.3
+opencv-python>=4.8.0
+Pillow>=10.0.0
+python-levenshtein>=0.21.0  # métricas
 
 # Vector Database
 chromadb>=0.4.0
@@ -38,6 +43,7 @@ psycopg2-binary>=2.9.0
 
 # OpenAI (backup direct client)
 openai>=1.0.0
+
 
 # ================================
 # NUEVAS DEPENDENCIAS PARA AGENTIC RAG
@@ -95,6 +101,11 @@ loguru>=0.7.2
 pypdf>=4.0.0
 python-docx>=1.1.0
 docx2txt>=0.8
+pytesseract>=0.3.10
+pdf2image>=1.16.3
+opencv-python>=4.8.0
+Pillow>=10.0.0
+python-levenshtein>=0.21.0  # métricas
 
 # Vector Database
 chromadb>=0.4.0


### PR DESCRIPTION
## Summary
- add OCR and metric packages to requirements
- note Tesseract OCR system dependency in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68977ec20450832bbb6bf6667839fb59